### PR TITLE
Deploying addin to appdata and use nuget for Revit API 

### DIFF
--- a/src/RevitGraphQLCommand/Revit2GraphQL.addin
+++ b/src/RevitGraphQLCommand/Revit2GraphQL.addin
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<RevitAddIns>
+  <AddIn Type="Application">
+    <Name>Local GraphQL Endpoint</Name>
+    <Assembly>RevitGraphQLCommand/RevitGraphQLCommand.dll</Assembly>
+    <AddInId>73dc677a-5a96-41dd-b3be-ca81d06dfc2c</AddInId>
+    <FullClassName>RevitGraphQLCommand.App</FullClassName>
+    <VendorId>Microdesk</VendorId>
+    <VendorDescription>https://www.microdesk.com/bimrx/</VendorDescription>
+  </AddIn>
+</RevitAddIns>

--- a/src/RevitGraphQLCommand/RevitGraphQLCommand.csproj
+++ b/src/RevitGraphQLCommand/RevitGraphQLCommand.csproj
@@ -73,8 +73,19 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+    <None Include="Revit2GraphQL.addin">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\RevitGraphQLResolver\RevitGraphQLResolver.csproj">
+      <Project>{f5e2f94e-dc93-4a71-a8df-5c13d97bc601}</Project>
+      <Name>RevitGraphQLResolver</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\RevitGraphQLSchema\RevitGraphQLSchema.csproj">
+      <Project>{b5b78760-cc43-477d-a6ee-ce1276dccb66}</Project>
+      <Name>RevitGraphQLSchema</Name>
+    </ProjectReference>
     <ProjectReference Include="..\RevitWebServer\RevitWebServer.csproj">
       <Project>{053728e3-50db-46bf-9d23-772570bd24b7}</Project>
       <Name>RevitWebServer</Name>
@@ -92,4 +103,13 @@
     </Resource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>if $(ConfigurationName) == Debug (
+mkdir "$(AppData)\Autodesk\REVIT\Addins\2020\$(TargetName)\"
+if exist "$(AppData)\Autodesk\REVIT\Addins\2020" copy "$(TargetDir)*.addin" "$(AppData)\Autodesk\REVIT\Addins\2020\"
+if exist "$(AppData)\Autodesk\REVIT\Addins\2020" copy  "$(TargetDir)*" "$(AppData)\Autodesk\REVIT\Addins\2020\$(TargetName)\" 
+
+)
+</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/src/RevitMarconiCommand/RevitMarconi.addin
+++ b/src/RevitMarconiCommand/RevitMarconi.addin
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RevitAddIns>
+  <AddIn Type="Application">
+    <Name>BIMrx.Marconi</Name>
+    <Assembly>RevitMarconiCommand\RevitMarconiCommand.dll</Assembly>
+    <AddInId>26516f0e-cdb2-43d0-9169-b4473db259ac</AddInId>
+    <FullClassName>RevitMarconiCommand.App</FullClassName>
+    <VendorId>Microdesk</VendorId>
+    <VendorDescription>https://www.microdesk.com/bimrx/</VendorDescription>
+  </AddIn>
+</RevitAddIns>

--- a/src/RevitMarconiCommand/RevitMarconiCommand.csproj
+++ b/src/RevitMarconiCommand/RevitMarconiCommand.csproj
@@ -33,6 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AdWindows, Version=2018.11.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Revit.2020.Assemblies.1.0.0\lib\AdWindows.dll</HintPath>
+    </Reference>
     <Reference Include="GraphQL, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\GraphQL.2.4.0\lib\net45\GraphQL.dll</HintPath>
     </Reference>
@@ -68,11 +71,20 @@
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="RevitAPI">
-      <HintPath>..\..\..\Program Files\Autodesk\Revit 2020\RevitAPI.dll</HintPath>
+    <Reference Include="RevitAPI, Version=20.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\Revit.2020.Assemblies.1.0.0\lib\RevitAPI.dll</HintPath>
     </Reference>
-    <Reference Include="RevitAPIUI">
-      <HintPath>..\..\..\Program Files\Autodesk\Revit 2020\RevitAPIUI.dll</HintPath>
+    <Reference Include="RevitAPIIFC, Version=20.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\Revit.2020.Assemblies.1.0.0\lib\RevitAPIIFC.dll</HintPath>
+    </Reference>
+    <Reference Include="RevitAPIMacros, Version=20.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\Revit.2020.Assemblies.1.0.0\lib\RevitAPIMacros.dll</HintPath>
+    </Reference>
+    <Reference Include="RevitAPIUI, Version=20.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\Revit.2020.Assemblies.1.0.0\lib\RevitAPIUI.dll</HintPath>
+    </Reference>
+    <Reference Include="RevitAPIUIMacros, Version=20.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\Revit.2020.Assemblies.1.0.0\lib\RevitAPIUIMacros.dll</HintPath>
     </Reference>
     <Reference Include="RevitTask, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\RevitTask.3.0.0\lib\net47\RevitTask.dll</HintPath>
@@ -201,6 +213,9 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+    <None Include="RevitMarconi.addin">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Resources\phone.png">
@@ -214,4 +229,13 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>if $(ConfigurationName) == Debug (
+mkdir "$(AppData)\Autodesk\REVIT\Addins\2020\$(TargetName)\"
+if exist "$(AppData)\Autodesk\REVIT\Addins\2020" copy "$(TargetDir)*.addin" "$(AppData)\Autodesk\REVIT\Addins\2020\"
+if exist "$(AppData)\Autodesk\REVIT\Addins\2020" copy  "$(TargetDir)*" "$(AppData)\Autodesk\REVIT\Addins\2020\$(TargetName)\" 
+
+)
+</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/src/RevitMarconiCommand/packages.config
+++ b/src/RevitMarconiCommand/packages.config
@@ -11,6 +11,7 @@
   <package id="Microsoft.IdentityModel.Logging" version="6.7.1" targetFramework="net472" />
   <package id="Microsoft.IdentityModel.Tokens" version="6.7.1" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net472" />
+  <package id="Revit.2020.Assemblies" version="1.0.0" targetFramework="net472" />
   <package id="RevitTask" version="3.0.0" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net472" />


### PR DESCRIPTION
Main changes 

- Deploy using a post build event directly to %appdata%.
- Includes both .addin files pointing to a relative path making it easier to share the compiled version (copy/paste to other users).
- Referencing Revit API dlls directly from nuget